### PR TITLE
fix(Simplex): may cause zero division error

### DIFF
--- a/src/Simplex.cc
+++ b/src/Simplex.cc
@@ -58,7 +58,7 @@ void SimplexClass::Simplex () {
             // Handle cases of distanceRow = 0
             for ( int i = 0; i < parameters.knn; i++ ) {
                 if ( distanceRow[i] > 0 ) {
-                    weightedDistances[i] = exp( -distanceRow[i] / minDistance );
+                    weightedDistances[i] = 0;
                 }
                 else {
                     // Setting weight = 1 implies that the corresponding


### PR DESCRIPTION
The zero division error may occur in lines 57-63 of simplex.cc (`distanceRow[i] / minDistance` when `minDistance == 0`).